### PR TITLE
Exposing the --mobb-project-name from Bugsy to GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This action posts the code and a SAST report to the Mobb vulnerability analysis 
 
 **Required** The GitHub api token to use with the action. Usually available as `${{ secrets.GITHUB_TOKEN }}`.
 
-## `mobb-project-name`
+## `mobb-project-name` 
 
 **Optional** The Mobb Project Name where the fix analysis will be stored. If this is not specified, it will the analysis will default into the "My first project". 
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ inputs:
   mobb-project-name:
     description: "Mobb Project Name"
     required: false
+    default: 'My first project'
 outputs:
   fix-report-url:
     description: "Mobb fix report URL"

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
         REPO=$(git remote get-url origin)
         REPO=${REPO%".git"}
         BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-        OUT=$(npx --yes mobbdev@latest analyze --ci -r $REPO --ref $BRANCH --api-key ${{ inputs.api-key }} -f ${{ inputs.report-file }} --mobb-project-name ${{ inputs. }})
+        OUT=$(npx --yes mobbdev@latest analyze --ci -r $REPO --ref $BRANCH --api-key ${{ inputs.api-key }} -f ${{ inputs.report-file }} --mobb-project-name ${{ inputs.mobb-project-name }})
         RETVAL=$?
         if [ $RETVAL -ne 0 ]; then
           exit $RETVAL

--- a/review/action.yml
+++ b/review/action.yml
@@ -16,6 +16,10 @@ inputs:
   scanner:
     description: "SAST scanner(codeql, snyk, checkmarx, fortify)"
     required: true
+  mobb-project-name:
+    description: "Mobb Project Name"
+    required: false
+
 outputs:
   fix-report-url:
     description: "Mobb fix report URL"
@@ -34,7 +38,7 @@ runs:
         SCANNER=${{ inputs.scanner }}
         
         PR_NUMBER=${{ github.event.pull_request.number }}
-        OUT=$(npx --yes mobbdev@latest review  -r $REPO --ref $GITHUB_HEAD_REF --ch $GITHUB_SHA --api-key ${{ inputs.api-key }} -f ${{ inputs.report-file }}  --pr $PR_NUMBER --github-token ${{ inputs.github-token }} --scanner $SCANNER)
+        OUT=$(npx --yes mobbdev@latest review  -r $REPO --ref $GITHUB_HEAD_REF --ch $GITHUB_SHA --api-key ${{ inputs.api-key }} -f ${{ inputs.report-file }}  --pr $PR_NUMBER --github-token ${{ inputs.github-token }} --scanner $SCANNER --mobb-project-name ${{ inputs.mobb-project-name }})
         RETVAL=$?
         if [ $RETVAL -ne 0 ]; then
           exit $RETVAL


### PR DESCRIPTION
This exposes the --mobb-project-name from Bugsy to GitHub Action and allow the user of this action to supply a custom Mobb Project Name that they wish the fix analysis to be stored. 

