### PR TITLE
Ignore errors in exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This action posts the code and a SAST report to the Mobb vulnerability analysis 
 
 **Optional** `true` or `false`. This requires `auto-pr` to be set to `true`. Once set, Fixes will be committed directly to the source branch. 
 
+## `organization-id`
+
+**Optional** The Organization ID to use with the Mobb platform. If not specified, the default organization will be used.
+
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   commit-directly:
     description: "Commit Directly flag, this requires Auto-PR flag to be set. Once enabled, Mobb will commit the fixes directly to the branch"
     required: false
+  organization-id:
+    description: "Organization ID"
+    required: false
 
 outputs:
   fix-report-url:
@@ -45,6 +48,12 @@ runs:
         if [ -n "${{ inputs.mobb-project-name }}" ]; then
           echo "mobb-project-name specified: ${{ inputs.mobb-project-name }}"
           MobbExecString+=" --mobb-project-name \"${{ inputs.mobb-project-name }}\""
+        fi
+
+        # Check if organization-id exists and append it
+        if [ -n "${{ inputs.organization-id }}" ]; then
+          echo "organization-id specified: ${{ inputs.organization-id }}"
+          MobbExecString+=" --organization-id \"${{ inputs.organization-id }}\""
         fi
 
         # Check if auto-pr flag is set append it

--- a/review/action.yml
+++ b/review/action.yml
@@ -70,12 +70,7 @@ runs:
 
         # Output the final command string for debugging
         echo "Mobb Command: $MobbExecString"
-        OUT=$(eval $MobbExecString)
-
-        RETVAL=$?
-        if [ $RETVAL -ne 0 ]; then
-          exit $RETVAL
-        fi
+        OUT=$(eval $MobbExecString || true)
         OUT=$(echo $OUT | tr '\n' ' ')
 
         echo "fix-report-url=$OUT" >> $GITHUB_OUTPUT

--- a/review/action.yml
+++ b/review/action.yml
@@ -79,6 +79,7 @@ runs:
       shell: bash -l {0}
 
     - uses: Sibz/github-status-action@v1
+      if: ${{ startsWith(steps.run-npx-mobb-dev.outputs.fix-report-url, 'https://') }}
       with:
         authToken: ${{ inputs.github-token }}
         context: "Mobb fix report link"

--- a/review/action.yml
+++ b/review/action.yml
@@ -79,7 +79,7 @@ runs:
       shell: bash -l {0}
 
     - uses: Sibz/github-status-action@v1
-      if: ${{ startsWith(steps.run-npx-mobb-dev.outputs.fix-report-url, 'https://') }}
+      if: ${{ steps.run-npx-mobb-dev.outputs.fix-report-url != '' }}
       with:
         authToken: ${{ inputs.github-token }}
         context: "Mobb fix report link"

--- a/review/action.yml
+++ b/review/action.yml
@@ -79,7 +79,7 @@ runs:
       shell: bash -l {0}
 
     - uses: Sibz/github-status-action@v1
-      if: ${{ steps.run-npx-mobb-dev.outputs.fix-report-url != '' }}
+      if: ${{ startsWith(steps.run-npx-mobb-dev.outputs.fix-report-url, 'https://') }}
       with:
         authToken: ${{ inputs.github-token }}
         context: "Mobb fix report link"


### PR DESCRIPTION
I tested this action by purposely supplying a wrong API key, and it is now failing with a black checkbox (which is the intention of this change) instead of a red "X"

<img width="1945" height="918" alt="image" src="https://github.com/user-attachments/assets/45ea01af-94e9-42e8-93ce-58c00fc45696" />
