### PR TITLE
TEST: verify shell injection is blocked with branch name test-$(id)

### DIFF
--- a/INJECTION_TEST.md
+++ b/INJECTION_TEST.md
@@ -1,0 +1,1 @@
+# Injection test - this branch name is test-$(id)

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ runs:
         REPO=${REPO%".git"}
         BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
+        echo "REPO: $REPO"
+        echo "BRANCH: $BRANCH"
+
         MOBB_ARGS=(
           npx --yes mobbdev@latest analyze --ci
           -r "$REPO"

--- a/review/action.yml
+++ b/review/action.yml
@@ -57,6 +57,11 @@ runs:
         VUL_FILE_PATH="results/$(basename "$REPORT_FILE")"
         PR_NUMBER="${{ github.event.pull_request.number }}"
 
+        echo "REPO: $REPO"
+        echo "BRANCH: $GITHUB_HEAD_REF"
+        echo "COMMIT_HASH: $COMMIT_HASH"
+        echo "PR_NUMBER: $PR_NUMBER"
+
         MOBB_ARGS=(
           npx --yes mobbdev@latest review
           -r "$REPO"


### PR DESCRIPTION
## What this tests

This PR exists solely to verify that the security fix on `action/E-1815` works.

The branch name is `test-$(id)`. If the injection vulnerability still existed,
`$(id)` would execute as a shell command and the logs would show something like
`uid=1001(runner)`.

If the fix works, the logs should show the literal string `test-$(id)` without
executing anything.

**Close this PR after verifying the logs. Do not merge.**