### PR TITLE
feat: support scan-and-fix mode and diff-aware scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The Mobb fix report URL.
 
 ### Fix-only mode with an existing SAST report (Checkmarx)
 
-```
+```yaml
 # This example utilizes Mobb with Checkmarx via GitHub Actions
 
 on: [pull_request]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 This action posts the code and a SAST report to the Mobb vulnerability analysis engine and links the URL of the fix report to the PR. If you are using this on a private repo then the Mobb user the API key belongs to must have access to the repo and must approve github access for the user on the Mobb platform beforehand.
 
+The action supports two modes:
+
+- **Fix-only mode (default)**: provide an existing SAST report via `report-file` and Mobb generates fixes for the findings.
+- **Scan-and-fix mode**: omit `report-file` and the Mobb CLI runs its own SAST scan (powered by opengrep) before producing fixes. Combine with `diff-aware: true` on pull requests to limit the scan to changes since the PR base commit.
+
 ## Inputs
 
 ## `report-file`
 
-**Required** The full path of the SAST report file.
+**Optional** The full path of the SAST report file. Omitting this input switches the action into **scan-and-fix mode**: the Mobb CLI performs its own internal SAST scan (via opengrep) instead of consuming an external report.
 
 ## `api-key`
 
@@ -32,6 +37,10 @@ This action posts the code and a SAST report to the Mobb vulnerability analysis 
 
 **Optional** The Organization ID to use with the Mobb platform. If not specified, the default organization will be used.
 
+## `diff-aware`
+
+**Optional** `true` or `false` (default `false`). Part of Mobb's scan-and-fix mode (enabled by omitting `report-file`). When set to `true` and the workflow is triggered by a `pull_request` event, Mobb performs a diff-aware scan limited to changes since the PR base SHA (passed to the CLI as `--baseline-commit`). Has no effect outside a pull request context.
+
 
 ## Outputs
 
@@ -40,6 +49,45 @@ This action posts the code and a SAST report to the Mobb vulnerability analysis 
 The Mobb fix report URL.
 
 ## Example usage
+
+### Scan-and-fix mode with diff-aware scanning (no external SAST tool required)
+
+```yaml
+# Mobb runs its own SAST scan on the PR diff and opens fix PRs automatically.
+
+name: Mobb Scan-and-Fix
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  scan-and-fix:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Mobb scan-and-fix
+        uses: mobb-dev/action@v1
+        with:
+          # report-file intentionally omitted -> enables scan-and-fix mode
+          api-key: ${{ secrets.MOBB_API_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          diff-aware: true
+          auto-pr: true
+```
+
+> Note: `diff-aware: true` requires a `pull_request` (or `pull_request_target`) trigger so the action can read `github.event.pull_request.base.sha`. On other event types the flag is silently ignored and Mobb falls back to a full scan.
+
+### Fix-only mode with an existing SAST report (Checkmarx)
 
 ```
 # This example utilizes Mobb with Checkmarx via GitHub Actions

--- a/README.md
+++ b/README.md
@@ -50,43 +50,6 @@ The Mobb fix report URL.
 
 ## Example usage
 
-### Scan-and-fix mode with diff-aware scanning (no external SAST tool required)
-
-```yaml
-# Mobb runs its own SAST scan on the PR diff and opens fix PRs automatically.
-
-name: Mobb Scan-and-Fix
-
-on:
-  pull_request:
-    branches:
-      - main
-
-jobs:
-  scan-and-fix:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      statuses: write
-      contents: read
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Mobb scan-and-fix
-        uses: mobb-dev/action@v1
-        with:
-          # report-file intentionally omitted -> enables scan-and-fix mode
-          api-key: ${{ secrets.MOBB_API_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          diff-aware: true
-          auto-pr: true
-```
-
-> Note: `diff-aware: true` requires a `pull_request` (or `pull_request_target`) trigger so the action can read `github.event.pull_request.base.sha`. On other event types the flag is silently ignored and Mobb falls back to a full scan.
-
 ### Fix-only mode with an existing SAST report (Checkmarx)
 
 ```
@@ -130,3 +93,40 @@ jobs:
           api-key: ${{ secrets.MOBB_API_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+### Scan-and-fix mode with diff-aware scanning (no external SAST tool required)
+
+```yaml
+# Mobb runs its own SAST scan on the PR diff and opens fix PRs automatically.
+
+name: Mobb Scan-and-Fix
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  scan-and-fix:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Mobb scan-and-fix
+        uses: mobb-dev/action@v1
+        with:
+          # report-file intentionally omitted -> enables scan-and-fix mode
+          api-key: ${{ secrets.MOBB_API_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          diff-aware: true
+          auto-pr: true
+          auto-commit: true
+```
+
+> Note: `diff-aware: true` requires a `pull_request` (or `pull_request_target`) trigger so the action can read `github.event.pull_request.base.sha`. On other event types the flag is silently ignored and Mobb falls back to a full scan.

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,8 @@ branding:
   color: blue
 inputs:
   report-file:
-    description: "Path to SAST report file"
-    required: true
+    description: "Path to SAST report file. Omitting this input enables Mobb's scan-and-fix mode: the Mobb CLI performs its own internal SAST scan (via opengrep) instead of consuming an external report."
+    required: false
   api-key:
     description: "Mobb API key"
     required: true
@@ -25,6 +25,10 @@ inputs:
   organization-id:
     description: "Organization ID"
     required: false
+  diff-aware:
+    description: "Part of Mobb's scan-and-fix mode (enabled by omitting report-file). When true and the workflow is triggered by a pull_request event, Mobb performs a diff-aware scan limited to changes since the PR base SHA (passed as --baseline-commit). Has no effect outside PR context. Defaults to false."
+    required: false
+    default: "false"
 
 outputs:
   fix-report-url:
@@ -42,8 +46,16 @@ runs:
         REPO=${REPO%".git"}
         BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
-        MobbExecString="npx --yes mobbdev@latest analyze --ci -r $REPO --ref $BRANCH --api-key ${{ inputs.api-key }} -f ${{ inputs.report-file }}"
-        
+        MobbExecString="npx --yes mobbdev@latest analyze --ci -r $REPO --ref $BRANCH --api-key ${{ inputs.api-key }}"
+
+        # Append -f only if a report file was provided. When omitted, Mobb runs in scan-and-fix mode (internal opengrep scan).
+        if [ -n "${{ inputs.report-file }}" ]; then
+          echo "report-file specified: ${{ inputs.report-file }}"
+          MobbExecString+=" -f ${{ inputs.report-file }}"
+        else
+          echo "No report-file provided. Running in scan-and-fix mode (Mobb CLI will perform internal SAST scan)."
+        fi
+
         # Check if mobb-project-name exists and append it
         if [ -n "${{ inputs.mobb-project-name }}" ]; then
           echo "mobb-project-name specified: ${{ inputs.mobb-project-name }}"
@@ -74,6 +86,17 @@ runs:
             MobbExecString+=" --pr-id $PR_ID"
           else
             echo "No Pull Request detected. Skipping --pr-id flag."
+          fi
+        fi
+
+        # When diff-aware scan-and-fix is enabled and we are in a PR context, point --baseline-commit at the PR base SHA.
+        if [ "${{ inputs.diff-aware }}" == "true" ]; then
+          BASELINE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ -n "$BASELINE_SHA" ]; then
+            echo "diff-aware enabled, using baseline commit: $BASELINE_SHA"
+            MobbExecString+=" --baseline-commit $BASELINE_SHA"
+          else
+            echo "diff-aware enabled but no pull_request context detected; skipping --baseline-commit."
           fi
         fi
 


### PR DESCRIPTION
## Summary
- Make `report-file` optional. Omitting it enables Mobb's **scan-and-fix mode**: the Mobb CLI runs its own SAST scan (internal opengrep) instead of consuming an external SARIF/JSON report.
- Add a new optional `diff-aware` input (default `false`). When set to `true` and the workflow is triggered by a `pull_request` event, the action passes `--baseline-commit <pr.base.sha>` to `mobbdev analyze`, enabling diff-aware scanning. Outside of PR context the flag is silently ignored.
- README updated with a scan-and-fix example workflow and a description of the two modes.

No changes to the existing fix-only flow — workflows that already pass `report-file` keep working unchanged.

## Test plan
- [x] Run a workflow with `report-file` set (existing fix-only path) and confirm `-f <path>` still appears in the logged Mobb command.
- [x] Run a workflow without `report-file` and confirm the log says "Running in scan-and-fix mode" and no `-f` is appended.
- [x] Run a `pull_request` workflow with `diff-aware: true` and confirm `--baseline-commit <sha>` is appended using `github.event.pull_request.base.sha`.
- [ ] Run a `push` (non-PR) workflow with `diff-aware: true` and confirm the action logs the skip message and does **not** append `--baseline-commit`.